### PR TITLE
Fix Typescript nullable and index types

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,14 +48,14 @@ function fooGood<T extends { x: number }>(obj: T): T {
 
 https://flowtype.org/blog/2015/03/12/Bounded-Polymorphism.html
 
-## nullable type
+## maybe & nullable type
 
 ### Flow
 
 ```js
 let a: ?string
 
-// or:
+// equvalent to:
 
 let a: string | null | void
 ```
@@ -63,14 +63,6 @@ let a: string | null | void
 ### TypeScript
 
 ```ts
-let a: string | undefined
-
-// or:
-
-let a: string | null
-
-// or:
-
 let a: string | null | undefined
 ```
 

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ TypeScript is more strict here, in that if you want to use a property which is n
 
 ```js
 type ExactUser = { name: string, age: number };
-type User = { name: string, age: number, [otherProperty: any] };
+type User = { name: string, age: number, [otherProperty: string]: any };
 type OptionalUser = Partial<{ name: string, age: number }>; // all properties become optional
 ```
 

--- a/README.md
+++ b/README.md
@@ -63,11 +63,23 @@ let a: string | null | void
 ### TypeScript
 
 ```ts
-let a: string?
+let a: string | undefined
+
+// or:
+
+let a: string | null
 
 // or:
 
 let a: string | null | undefined
+```
+
+Optional parameters implicitly add `undefined`:
+
+```ts
+function f(x?: number) { }
+// same as:
+function f(x?: number | undefined) { }
 ```
 
 ## type casting
@@ -276,7 +288,7 @@ type A = {
   thing: string
 }
 
-type lookedUpThing = typeof A['thing']
+type lookedUpThing = A['thing']
 ```
 
 ## Mapped Types / Foreach Property


### PR DESCRIPTION
1. Typescript doesn't have special type syntax for nullable/optional
types. Also it treats nullable (`| null`) and optional (`| undefined`)
types separately.
2. `typeof` isn't needed with index types -- they are types themselves.