### PR TITLE
Add function statics and object callable properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,27 +542,6 @@ function add(x, y) {
 }
 ```
 
-
-## Function statics
-
-### Flow
-
-Functions are also objects and you can annotate function statics.
-
-```js
-function foo(): string {
-  (foo.bar: string);
-  if (!foo.bar) {
-    foo.bar = "hello";
-  }
-  return foo.bar;
-}
-```
-
-### TypeScript
-
-<!-- TODO: Need advise on TypeScript support for function statics -->
-
 ## Read-only Types
 
 ### Flow
@@ -662,6 +641,8 @@ Most of the syntax of Flow and TypeScript is the same. TypeScript is more expres
 
 The basic syntax are the same, except Flow has special syntax for the internal call property slot.
 
+Both can be used to annotate function statics.
+
 ### Flow
 
 You can use objects with callable properties as functions: [Try Flow](https://flow.org/try/#0PTAEAEDMBsHsHcBQiAuBPADgU1AMVALygDeiooAFAJQBcoAzigE4CWAdgOaIC+A3IgGNYbRqEh18RaoQB8oAEQALLNDjz+QkSlDLVsOo1adCY6ryA)
@@ -686,6 +667,28 @@ type F = {
 
 const f: F = (x?: number | string) => {
   return x ? x.toString() : '';
+}
+```
+
+Use call property to annotate function statics: [Try Flow](https://flow.org/try/#0PTAEAEDMBsHsHcBQiAuBPADgU1AWSwLawCWAXlgCYBiAhgMYqwBOxN0AKpjgLygDeiUKDr0AFlgBc-QaACQAbQB2AVwIAjLEwC6Ules0yAvgBoZ8+SOjQtWgBR6NTAJS7Vj04eR1YigM4pQSHpGFjYpfCIySloGZlYOLlBeRSSAPmkhYkhQWwBCINjQ6AA6ETpxJwyhQOC4tlKxHn5PIRbQLJyCkPiG8qwlLVBc7l5lRQosSGJFSkqBatAmLBRlJhSuupKy8QGjGQ2i3p3FQeSkkdAABlAAflAARlBdUAAqGsL4+1AAWgenGSWKzW7269W2-ROiEMQA)
+
+```js
+type MemoizedFactorialType = {
+  cache: {
+    [number]: number,
+  },
+  [[call]](number): number,
+}
+
+const factorial: MemoizedFactorialType = n => {
+  if (!factorial.cache) {
+    factorial.cache = {}
+  }
+  if (factorial.cache[n] !== undefined) {
+    return factorial.cache[n]
+  }
+  factorial.cache[n] = n === 0 ? 1 : n * factorial(n - 1)
+  return factorial.cache[n]
 }
 ```
 
@@ -715,12 +718,34 @@ This is also supported by TypeScript: [TypeScript Playground](https://www.typesc
 ```ts
 type F = {
   (): string,
-  (number): string,
-  (string): string
+  (x: number): string,
+  (x: string): string
 }
 
 const f: F = (x?: number | string) => {
   return x ? x.toString() : '';
+}
+```
+
+Use call property to annotate function statics: [TypeScript Playground](https://www.typescriptlang.org/play/#src=type%20MemoizedFactorialType%20%3D%20%7B%0D%0A%20%20cache%3F%3A%20%7B%0D%0A%20%20%20%20%5Bn%3A%20number%5D%3A%20number%2C%0D%0A%20%20%7D%2C%0D%0A%20%20(n%3A%20number)%3A%20number%2C%0D%0A%7D%0D%0A%0D%0Aconst%20factorial%3A%20MemoizedFactorialType%20%3D%20n%20%3D%3E%20%7B%0D%0A%20%20if%20(!factorial.cache)%20%7B%0D%0A%20%20%20%20factorial.cache%20%3D%20%7B%7D%0D%0A%20%20%7D%0D%0A%20%20else%20if%20(factorial.cache%5Bn%5D%20!%3D%3D%20undefined)%20%7B%0D%0A%20%20%20%20return%20factorial.cache%5Bn%5D%0D%0A%20%20%7D%0D%0A%20%20factorial.cache%5Bn%5D%20%3D%20n%20%3D%3D%3D%200%20%3F%201%20%3A%20n%20*%20factorial(n%20-%201)%0D%0A%20%20return%20factorial.cache%5Bn%5D%0D%0A%7D)
+
+```ts
+type MemoizedFactorialType = {
+  cache?: {
+    [n: number]: number,
+  },
+  (n: number): number,
+}
+
+const factorial: MemoizedFactorialType = n => {
+  if (!factorial.cache) {
+    factorial.cache = {}
+  }
+  else if (factorial.cache[n] !== undefined) {
+    return factorial.cache[n]
+  }
+  factorial.cache[n] = n === 0 ? 1 : n * factorial(n - 1)
+  return factorial.cache[n]
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -519,6 +519,8 @@ add("1", "1"); // Ok
 add(1, "1"); // Error
 ```
 
+It is also possible to create function overloads using callable property syntax, see the section [Object callable property](#object-callable-property).
+
 ### TypeScript
 
 TypeScript supports both function and method overloading, in both: type definitions (`.d.ts`) and inline alongside code.
@@ -544,54 +546,65 @@ function add(x, y) {
 
 ### Flow
 
-You can use objects with callable properties as functions.
+You can use objects with callable properties as functions: [Try Flow](https://flow.org/try/#0PTAEAEDMBsHsHcBQiAuBPADgU1AMVALygDeiooAFAJQBcoAzigE4CWAdgOaIC+A3IgGNYbRqEh18RaoQB8oAEQALLNDjz+QkSlDLVsOo1adCY6ryA)
 
 ```js
-type ReturnString = {
+type F = {
   (): string
 };
-const foo: ReturnString = () => "hello";
-const bar: string = foo();
+const f: F = () => "hello";
+const hello: string = f();
 ```
 
-Multiple call properties are supported
+An overloaded function is a function with multiple call signatures.
+This is supported by Flow. And we list out the different syntaxes here: [Try Flow](https://flow.org/try/#0PTAEAEDMBsHsHcBQiAuBPADgU1AMVALygDeiooAFAJQBcoAzigE4CWAdgOYA0ZoA2nwDGAQ2jQAuuLoU2AVwC2AIyxMqhAHwNm7brwEixkio1adaW0x0QBfZINhtGoSHXxEKADwD8dOUpWgAD4WOmoEmqTkTFgoskxsoB6gXokAdCiwAMranNSgdADkBQDcNohAA)
 
 ```js
-const foo: { (): string, (x: number): string } = function(x?: number): string {
-  return "bar";
-};
+type F = {
+  (): string,	
+  [[call]]: (number) => string,	
+  [[call]](string): string
+}
+
+const f: F = (x?: number | string) => {
+  return x ? x.toString() : '';
+}
 ```
 
 Reference:
 
-[Callable Objects](https://flow.org/en/docs/types/functions/#callable-objects-)
+- [Callable Objects](https://flow.org/en/docs/types/functions/#callable-objects-)
 
 ### TypeScript
 
+You can use objects with callable properties as functions: [TypeScript Playground](https://www.typescriptlang.org/play/#src=type%20F%20%3D%20%7B%0D%0A%20%20()%3A%20string%3B%0D%0A%7D%0D%0Aconst%20foo%3A%20F%20%3D%20()%20%3D%3E%20%22hello%22%3B%0D%0Aconst%20bar%3A%20string%20%3D%20foo()%3B)
+
 ```ts
-interface ReturnString {
+type F = {
   (): string;
 }
-const foo: ReturnString = () => "hello";
+const foo: F = () => "hello";
 const bar: string = foo();
 ```
 
-Overloading callable is supported
+An overloaded function is a function with multiple call signatures.
+This is also supported by TypeScript: [TypeScript Playground](https://www.typescriptlang.org/play/#src=type%20F%20%3D%20%7B%0D%0A%20%20()%3A%20string%2C%0D%0A%20%20(number)%3A%20string%2C%0D%0A%20%20(string)%3A%20string%0D%0A%7D%0D%0A%0D%0Aconst%20f%3A%20F%20%3D%20(x%3F%3A%20number%20%7C%20string)%20%3D%3E%20%7B%0D%0A%20%20return%20x%20%3F%20x.toString()%20%3A%20''%3B%0D%0A%7D%0D%0A)
+
 
 ```ts
-interface Overloaded {
-    (): string;
-    (x: number): string;
+type F = {
+  (): string,
+  (number): string,
+  (string): string
 }
 
-const foo: Overloaded = (x?: number) => { 
-    return 'bar';
+const f: F = (x?: number | string) => {
+  return x ? x.toString() : '';
 }
 ```
 
 Reference:
-
-[Callable](https://github.com/basarat/typescript-book/blob/master/docs/types/callable.md)
+- [Callable on TypeScript Book](https://github.com/basarat/typescript-book/blob/master/docs/types/callable.md)
 
 ## Function statics
 

--- a/README.md
+++ b/README.md
@@ -540,6 +540,36 @@ function add(x, y) {
 }
 ```
 
+## Function statics and object callable properties
+
+### Flow
+
+You can use objects with callable properties as function with statics. This is useful when annotating memoized functions.
+
+```js
+type MemoizedFactorialType = {
+  cache: {
+    [number]: number,
+  },
+  [[call]](number): number,  // callable property
+}
+
+const factorial: MemoizedFactorialType = n => {
+  if (!factorial.cache) {
+    factorial.cache = {}
+  }
+  if (factorial.cache[n] !== undefined) {
+    return factorial.cache[n]
+  }
+  factorial.cache[n] = n === 0 ? 1 : n * factorial(n - 1)
+  return factorial.cache[n]
+}
+```
+
+### TypeScript
+
+Not supported now, [proposal to tc39](https://github.com/microsoft/TypeScript/issues/25628).
+
 ## Read-only Types
 
 ### Flow

--- a/README.md
+++ b/README.md
@@ -563,6 +563,7 @@ function foo(): string {
 
 Not supported now, [proposal to tc39](https://github.com/microsoft/TypeScript/issues/25628).
 
+## Read-only Types
 
 ### Flow
 

--- a/README.md
+++ b/README.md
@@ -576,7 +576,18 @@ const foo: ReturnString = () => "hello";
 const bar: string = foo();
 ```
 
-<!-- TODO: veryfy use case in TypeScript -->
+Overloading callable is supported
+
+```ts
+interface Overloaded {
+    (): string;
+    (x: number): string;
+}
+
+const foo: Overloaded = (x?: number) => { 
+    return 'bar';
+}
+```
 
 Reference:
 

--- a/README.md
+++ b/README.md
@@ -561,7 +561,7 @@ function foo(): string {
 
 ### TypeScript
 
-Not supported now, [proposal to tc39](https://github.com/microsoft/TypeScript/issues/25628).
+<!-- TODO: Need advise on TypeScript support for function statics -->
 
 ## Read-only Types
 

--- a/README.md
+++ b/README.md
@@ -542,69 +542,6 @@ function add(x, y) {
 }
 ```
 
-## Object callable property
-
-### Flow
-
-You can use objects with callable properties as functions: [Try Flow](https://flow.org/try/#0PTAEAEDMBsHsHcBQiAuBPADgU1AMVALygDeiooAFAJQBcoAzigE4CWAdgOaIC+A3IgGNYbRqEh18RaoQB8oAEQALLNDjz+QkSlDLVsOo1adCY6ryA)
-
-```js
-type F = {
-  (): string
-};
-const f: F = () => "hello";
-const hello: string = f();
-```
-
-An overloaded function is a function with multiple call signatures.
-This is supported by Flow. And we list out the different syntaxes here: [Try Flow](https://flow.org/try/#0PTAEAEDMBsHsHcBQiAuBPADgU1AMVALygDeiooAFAJQBcoAzigE4CWAdgOYA0ZoA2nwDGAQ2jQAuuLoU2AVwC2AIyxMqhAHwNm7brwEixkio1adaW0x0QBfZINhtGoSHXxEKADwD8dOUpWgAD4WOmoEmqTkTFgoskxsoB6gXokAdCiwAMranNSgdADkBQDcNohAA)
-
-```js
-type F = {
-  (): string,	
-  [[call]]: (number) => string,	
-  [[call]](string): string
-}
-
-const f: F = (x?: number | string) => {
-  return x ? x.toString() : '';
-}
-```
-
-Reference:
-
-- [Callable Objects](https://flow.org/en/docs/types/functions/#callable-objects-)
-
-### TypeScript
-
-You can use objects with callable properties as functions: [TypeScript Playground](https://www.typescriptlang.org/play/#src=type%20F%20%3D%20%7B%0D%0A%20%20()%3A%20string%3B%0D%0A%7D%0D%0Aconst%20foo%3A%20F%20%3D%20()%20%3D%3E%20%22hello%22%3B%0D%0Aconst%20bar%3A%20string%20%3D%20foo()%3B)
-
-```ts
-type F = {
-  (): string;
-}
-const foo: F = () => "hello";
-const bar: string = foo();
-```
-
-An overloaded function is a function with multiple call signatures.
-This is also supported by TypeScript: [TypeScript Playground](https://www.typescriptlang.org/play/#src=type%20F%20%3D%20%7B%0D%0A%20%20()%3A%20string%2C%0D%0A%20%20(number)%3A%20string%2C%0D%0A%20%20(string)%3A%20string%0D%0A%7D%0D%0A%0D%0Aconst%20f%3A%20F%20%3D%20(x%3F%3A%20number%20%7C%20string)%20%3D%3E%20%7B%0D%0A%20%20return%20x%20%3F%20x.toString()%20%3A%20''%3B%0D%0A%7D%0D%0A)
-
-
-```ts
-type F = {
-  (): string,
-  (number): string,
-  (string): string
-}
-
-const f: F = (x?: number | string) => {
-  return x ? x.toString() : '';
-}
-```
-
-Reference:
-- [Callable on TypeScript Book](https://github.com/basarat/typescript-book/blob/master/docs/types/callable.md)
 
 ## Function statics
 
@@ -719,6 +656,76 @@ However, Flow implementation is stricter in this case, as B have a property that
 # Same syntax
 
 Most of the syntax of Flow and TypeScript is the same. TypeScript is more expressive for certain use-cases (advanced mapped types with keysof, readonly properties), and Flow is more expressive for others (e.g. `$Diff`).
+
+## Object callable property
+
+The basic syntax are the same, except Flow has special syntax for the internal call property slot.
+
+### Flow
+
+You can use objects with callable properties as functions: [Try Flow](https://flow.org/try/#0PTAEAEDMBsHsHcBQiAuBPADgU1AMVALygDeiooAFAJQBcoAzigE4CWAdgOaIC+A3IgGNYbRqEh18RaoQB8oAEQALLNDjz+QkSlDLVsOo1adCY6ryA)
+
+```js
+type F = {
+  (): string
+};
+const f: F = () => "hello";
+const hello: string = f();
+```
+
+An overloaded function is a function with multiple call signatures.
+This is supported by Flow. And we list out the different syntaxes here: [Try Flow](https://flow.org/try/#0PTAEAEDMBsHsHcBQiAuBPADgU1AMVALygDeiooAFAJQBcoAzigE4CWAdgOYA0ZoA2nwDGAQ2jQAuuLoU2AVwC2AIyxMqhAHwNm7brwEixkio1adaW0x0QBfZINhtGoSHXxEKADwD8dOUpWgAD4WOmoEmqTkTFgoskxsoB6gXokAdCiwAMranNSgdADkBQDcNohAA)
+
+```js
+type F = {
+  (): string,	
+  [[call]]: (number) => string,	
+  [[call]](string): string
+}
+
+const f: F = (x?: number | string) => {
+  return x ? x.toString() : '';
+}
+```
+
+Reference:
+
+- [Callable Objects](https://flow.org/en/docs/types/functions/#callable-objects-)
+- [immer.js](https://github.com/immerjs/immer/blob/master/src/immer.js.flow) uses it to overload the `produce` (default export) function which has multiple call signatures
+- [Styled Components](https://github.com/flow-typed/flow-typed/blob/master/definitions/npm/styled-components_v4.x.x/flow_v0.75.x-/styled-components_v4.x.x.js#L242) uses it to separate cases of being called on a string and wrapping a component 
+- [Reselect Library Definition](https://github.com/flow-typed/flow-typed/blob/master/definitions/npm/re-reselect_v2.x.x/flow_v0.67.1-/re-reselect_v2.x.x.js) contains massive chunks of overloaded call properties
+
+### TypeScript
+
+You can use objects with callable properties as functions: [TypeScript Playground](https://www.typescriptlang.org/play/#src=type%20F%20%3D%20%7B%0D%0A%20%20()%3A%20string%3B%0D%0A%7D%0D%0Aconst%20foo%3A%20F%20%3D%20()%20%3D%3E%20%22hello%22%3B%0D%0Aconst%20bar%3A%20string%20%3D%20foo()%3B)
+
+```ts
+type F = {
+  (): string;
+}
+const foo: F = () => "hello";
+const bar: string = foo();
+```
+
+An overloaded function is a function with multiple call signatures.
+This is also supported by TypeScript: [TypeScript Playground](https://www.typescriptlang.org/play/#src=type%20F%20%3D%20%7B%0D%0A%20%20()%3A%20string%2C%0D%0A%20%20(number)%3A%20string%2C%0D%0A%20%20(string)%3A%20string%0D%0A%7D%0D%0A%0D%0Aconst%20f%3A%20F%20%3D%20(x%3F%3A%20number%20%7C%20string)%20%3D%3E%20%7B%0D%0A%20%20return%20x%20%3F%20x.toString()%20%3A%20''%3B%0D%0A%7D%0D%0A)
+
+
+```ts
+type F = {
+  (): string,
+  (number): string,
+  (string): string
+}
+
+const f: F = (x?: number | string) => {
+  return x ? x.toString() : '';
+}
+```
+
+Reference:
+- [Callable on TypeScript Book](https://github.com/basarat/typescript-book/blob/master/docs/types/callable.md)
+
 
 ## optional parameters
 

--- a/README.md
+++ b/README.md
@@ -540,29 +540,61 @@ function add(x, y) {
 }
 ```
 
-## Function statics and object callable properties
+## Object callable property
 
 ### Flow
 
-You can use objects with callable properties as function with statics. This is useful when annotating memoized functions.
+You can use objects with callable properties as functions.
 
 ```js
-type MemoizedFactorialType = {
-  cache: {
-    [number]: number,
-  },
-  [[call]](number): number,  // callable property
-}
+type ReturnString = {
+  (): string
+};
+const foo: ReturnString = () => "hello";
+const bar: string = foo();
+```
 
-const factorial: MemoizedFactorialType = n => {
-  if (!factorial.cache) {
-    factorial.cache = {}
+Multiple call properties are supported
+
+```js
+const foo: { (): string, (x: number): string } = function(x?: number): string {
+  return "bar";
+};
+```
+
+Reference:
+
+[Callable Objects](https://flow.org/en/docs/types/functions/#callable-objects-)
+
+### TypeScript
+
+```ts
+interface ReturnString {
+  (): string;
+}
+const foo: ReturnString = () => "hello";
+const bar: string = foo();
+```
+
+<!-- TODO: veryfy use case in TypeScript -->
+
+Reference:
+
+[Callable](https://github.com/basarat/typescript-book/blob/master/docs/types/callable.md)
+
+## Function statics
+
+### Flow
+
+Functions are also objects and you can annotate function statics.
+
+```js
+function foo(): string {
+  (foo.bar: string);
+  if (!foo.bar) {
+    foo.bar = "hello";
   }
-  if (factorial.cache[n] !== undefined) {
-    return factorial.cache[n]
-  }
-  factorial.cache[n] = n === 0 ? 1 : n * factorial(n - 1)
-  return factorial.cache[n]
+  return foo.bar;
 }
 ```
 
@@ -570,7 +602,6 @@ const factorial: MemoizedFactorialType = n => {
 
 Not supported now, [proposal to tc39](https://github.com/microsoft/TypeScript/issues/25628).
 
-## Read-only Types
 
 ### Flow
 


### PR DESCRIPTION
What does this PR do?
---
Adds function statics that is present in Flow.

Anything the maintainer needs to take note?
---
The example in this addition works on 0.99 due to some fixes. Although callable property has been around Flow since 0.75 ([Store object call properties in internal slot ](https://github.com/facebook/flow/commit/b9db648afe4f2207a49985aa82b90a485a11a900), [Add support for [[call]] internal slot properties ](https://github.com/facebook/flow/commit/954a72704a6338778c940239573045b28c716488)), and its precursor syntax (already [deprecated in 0.75](https://github.com/facebook/flow/commit/df8ee96bc84b476f874e300b3cd3c07b430e085b) and [removed in 0.99](https://github.com/facebook/flow/commit/cbd64384dccaddaa8461d7850c24419e2217d13e)) was present at least before 0.47.